### PR TITLE
fix: use correct path to import help command

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -1,7 +1,7 @@
 package help_test
 
 import (
-	"github.com/rwxrob/bonzai/help"
+	"github.com/rwxrob/help"
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/term"
 )


### PR DESCRIPTION
This _should_ resolve an issue installing the help command with `go get`, which currently errors out due to this file importing rwxrob/bonzai/help instead of rwxrob/help.